### PR TITLE
Use mTLS auth between flink and Kafka and introduce install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+dependency-reduced-pom.xml
+.idea

--- a/01-setup.sh
+++ b/01-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+MINIKUBE_CPUS=4
+MINIKUBE_MEMORY=16384
+MINIKUBE_DISK_SIZE=25GB
+minikube delete
+minikube start
+kubectl create -f 'https://strimzi.io/install/latest?namespace=default' -n default
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.crds.yaml
+helm install cert-manager jetstack/cert-manager --namespace default --version v1.14.4
+helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.8.0/
+helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator

--- a/02-flink.sh
+++ b/02-flink.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+OS=$(uname)
+if [ "$OS" = 'Darwin' ]; then
+  SED=$(which gsed)
+else
+  SED=$(which sed)
+fi
+$SED -i "s/MINIKUBE_IP/$(minikube ip)/g" kafka.yaml
+kubectl apply -f kafka.yaml
+kubectl apply -f user.yaml
+echo "waiting for kafka to start, may take some time to download down images"
+kubectl wait kafka/my-cluster --for=condition=Ready --timeout=400s
+git checkout kafka.yaml
+echo "creating transactions topic, may take some time to download kafka image"
+kubectl run client -i --image quay.io/strimzi/kafka:latest-kafka-3.7.0 --restart=Never --rm --pod-running-timeout 2m0s -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --topic transactions --partitions 3 --create
+echo "building fraud-detection jar"
+mvn clean package
+echo "building fraud-detection image in minikube"
+minikube image build . -t fraud-detection:latest
+echo "applying flink fraud detection deployment"
+kubectl apply -f frauddetection_pvc.yaml
+kubectl apply -f frauddetection_ha.yaml

--- a/frauddetection_ha.yaml
+++ b/frauddetection_ha.yaml
@@ -29,12 +29,28 @@ spec:
           volumeMounts:
             - mountPath: /flink-data
               name: flink-volume
+          env:
+            - name: TLS_CLUSTER_CA_CRT
+              valueFrom:
+                secretKeyRef:
+                  name: my-cluster-cluster-ca-cert
+                  key: ca.crt
+            - name: TLS_USER_CRT
+              valueFrom:
+                secretKeyRef:
+                  name: mtls-user
+                  key: user.crt
+            - name: TLS_USER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mtls-user
+                  key: user.key
       volumes:
         - name: flink-volume
           persistentVolumeClaim:
             claimName: fraud-detection-pvc
   job:
     jarURI: local:///opt/flink/usrlib/frauddetection.jar
-    args: ["my-cluster-kafka-bootstrap.default.svc:9092", "mygroup1"]
+    args: ["my-cluster-kafka-external2-bootstrap:9095", "mygroup1"]
     parallelism: 2
     upgradeMode: stateless

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -19,6 +19,19 @@ spec:
         port: 9094
         type: nodeport
         tls: false
+      - name: external2
+        port: 9095
+        type: nodeport
+        tls: true
+        authentication:
+          type: tls
+        configuration:
+          preferredNodePortAddressType: InternalDNS
+          bootstrap:
+            alternativeNames:
+              - my-cluster-kafka-external2-bootstrap.default.svc
+              - my-cluster-kafka-external2-bootstrap
+              - MINIKUBE_IP
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
@@ -40,6 +53,6 @@ spec:
       type: persistent-claim
       size: 100Gi
       deleteClaim: false
-#  entityOperator:
+  entityOperator:
 #    topicOperator: {}
-#    userOperator: {}
+    userOperator: {}

--- a/user.yaml
+++ b/user.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: mtls-user
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls


### PR DESCRIPTION
1. The Kafka cluster runs a user operator
2. We install a user with mtls auth
3. We create another external nodeport listener with TLS auth enabled
4. We wire up the Flink deployment with the cluster ca certs, and the user certs and key via environment variables. The job reads them and configures the kafka clients.

Why:
We want to understand how the flink job can be configured to work with Strimzi auth modes like mtls and scramsha.

The scripts should avoid copying commands out of the README. They are split into:

- 01-setup.sh, delete and create minikube and install operators on it
- 02-flink.sh, install kafka, build the flink job image and deploy the flink job

Then it's on users to produce the transactions and consume alerts to see it in action.